### PR TITLE
Packaging: fix installing in a directory with GNU Make

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -27,5 +27,7 @@ test: test.c libg722.a
 	${CC} ${CFLAGS} -o test test.c libg722.a -lm
 
 install:
-	install libg722.a ${LIBDIR}
-	install ${SRCS_H} ${INCLUDEDIR}
+	install -d ${DESTDIR}${LIBDIR}
+	install libg722.a ${DESTDIR}${LIBDIR}
+	install -d ${DESTDIR}${INCLUDEDIR}
+	install ${SRCS_H} ${DESTDIR}${INCLUDEDIR}


### PR DESCRIPTION
Packaging usually involves installing a file into a directory, which is
passed to make through the DESTDIR variable.

This commit adds ${DESTDIR} as a prefix to the installation directories,
and also ensures the directories exist before copying the files over.

It is worth noting the BSD makefile already does that.
