### PR TITLE
Change C_STANDARD to C11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ option(ENABLE_STATIC_LIB "Build static library" ON)
 
 # lots of warnings and all warnings as errors
 ## add_compile_options(-Wall -Wextra )
-set(CMAKE_C_STANDARD 17)
+set(CMAKE_C_STANDARD 11)
 
 file(GLOB_RECURSE SRC_LIST_C CONFIGURE_DEPENDS  "${PROJECT_SOURCE_DIR}/g722*.c" )
 


### PR DESCRIPTION
C17 is not available until cmake 3.21, and it does not seem necessary