### PR TITLE
Add iOS build support and improve macOS build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Version.map
 *.so*
 __pycache__
 *.egg-info
+build/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,14 @@ cmake_minimum_required(VERSION 3.16)
 # set the project name
 project(libg722 C)
 
+# iOS-specific settings
+if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    set(ENABLE_SHARED_LIB OFF CACHE BOOL "Build shared library" FORCE)
+    set(ENABLE_STATIC_LIB ON CACHE BOOL "Build static library" FORCE)
+    set(BUILD_TESTING OFF CACHE BOOL "Build tests" FORCE)
+    message(STATUS "iOS build detected - using static library only")
+endif()
+
 option(ENABLE_SHARED_LIB "Build shared library" ON)
 option(ENABLE_STATIC_LIB "Build static library" ON)
 
@@ -10,7 +18,7 @@ option(ENABLE_STATIC_LIB "Build static library" ON)
 ## add_compile_options(-Wall -Wextra )
 set(CMAKE_C_STANDARD 11)
 
-file(GLOB_RECURSE SRC_LIST_C CONFIGURE_DEPENDS  "${PROJECT_SOURCE_DIR}/g722*.c" )
+set(SRC_LIST_C g722_decode.c g722_encode.c)
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   include(CTest)
@@ -40,9 +48,24 @@ if( ENABLE_STATIC_LIB )
   target_include_directories(g722_static PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 endif()
 
+# macOS-specific settings
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND NOT CMAKE_SYSTEM_NAME STREQUAL "iOS")
+    # Set a more appropriate default installation prefix for macOS
+    # Users can still override this with -DCMAKE_INSTALL_PREFIX=...
+    if(CMAKE_INSTALL_PREFIX STREQUAL "/usr/local")
+        set(CMAKE_INSTALL_PREFIX "$ENV{HOME}/Library/libg722" CACHE PATH "Installation prefix" FORCE)
+        message(STATUS "macOS detected - setting default install prefix to: ${CMAKE_INSTALL_PREFIX}")
+        message(STATUS "Override with: -DCMAKE_INSTALL_PREFIX=<path>")
+    endif()
+    
+    # Disable bitcode for macOS builds
+    add_compile_options(-fembed-bitcode=off)
+    message(STATUS "Bitcode disabled for macOS builds")
+endif()
+
 include(CheckIPOSupported)
 check_ipo_supported(RESULT lto_supported OUTPUT lto_error)
-if( lto_supported )
+if( lto_supported AND NOT CMAKE_SYSTEM_NAME STREQUAL "iOS" AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
   message(STATUS "LTO enabled")
   if( ENABLE_SHARED_LIB )
     set_property(TARGET g722 PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
@@ -53,5 +76,11 @@ if( lto_supported )
     set_property(TARGET test_static PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
   endif()
 else()
-    message(STATUS "LTO not supported: <${lto_error}>")
+    if(CMAKE_SYSTEM_NAME STREQUAL "iOS")
+        message(STATUS "LTO disabled for iOS builds")
+    elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+        message(STATUS "LTO disabled for macOS builds")
+    else()
+        message(STATUS "LTO not supported: <${lto_error}>")
+    endif()
 endif()

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,12 @@
 
 LIB=	g722
 SHLIB_MAJOR=	0
-PREFIX?= /usr/local
+# Detect macOS and set appropriate default prefix
+ifeq ($(shell uname -s),Darwin)
+    PREFIX?= $(HOME)/Library/libg722
+else
+    PREFIX?= /usr/local
+endif
 LIBDIR= ${PREFIX}/lib
 MK_PROFILE=	no
 INCLUDEDIR= ${PREFIX}/include

--- a/README.md
+++ b/README.md
@@ -33,10 +33,34 @@ Librarized by Sippy Software, Inc.
 
 ## Build and Install library:
 
+### MacOS & Linux
+
 ```
 git clone https://github.com/sippy/libg722.git
 cmake -B libg722/build -S libg722
-make -C ibg722/build clean all test install
+make -C libg722/build clean all test install
+```
+
+**Note for macOS users:** The library will be installed to `~/Library/libg722` by default. If you prefer a different location, you can specify it with:
+```
+cmake -B libg722/build -S libg722 -DCMAKE_INSTALL_PREFIX=/your/preferred/path
+```
+
+After installation, you may need to add the library path to your environment:
+```
+export DYLD_LIBRARY_PATH="$HOME/Library/libg722/lib:$DYLD_LIBRARY_PATH"
+```
+
+### iOS
+
+```
+git clone https://github.com/sippy/libg722.git
+cmake -B libg722/build-ios-device -S libg722 \
+  -DCMAKE_SYSTEM_NAME=iOS \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DCMAKE_OSX_SYSROOT=iphoneos \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
+make -C libg722/build-ios-device
 ```
 
 ## Install Python module from PyPy:

--- a/build_ios.sh
+++ b/build_ios.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+rm -rf build-macos build-ios-device build-ios-simulator g722.xcframework
+
+# Build for macOS
+cmake -B build-macos -S . \
+  -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=10.15
+make -C build-macos
+
+# Build for iOS device
+cmake -B build-ios-device -S . \
+  -DCMAKE_SYSTEM_NAME=iOS \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 \
+  -DCMAKE_OSX_SYSROOT=iphoneos \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
+make -C build-ios-device
+
+# Build for iOS simulator
+cmake -B build-ios-simulator -S . \
+  -DCMAKE_SYSTEM_NAME=iOS \
+  -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+  -DCMAKE_OSX_SYSROOT=iphonesimulator \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=12.0
+make -C build-ios-simulator
+
+# Create include directory and copy headers
+mkdir -p build-macos/include
+cp g722*.h build-macos/include/
+
+mkdir -p build-ios-device/include
+cp g722*.h build-ios-device/include/
+
+mkdir -p build-ios-simulator/include
+cp g722*.h build-ios-simulator/include/
+
+# Create the XCFramework
+xcodebuild -create-xcframework \
+  -library build-macos/libg722.a \
+  -headers build-macos/include \
+  -library build-ios-device/libg722.a \
+  -headers build-ios-device/include \
+  -library build-ios-simulator/libg722.a \
+  -headers build-ios-simulator/include \
+  -output g722.xcframework

--- a/test.c
+++ b/test.c
@@ -27,6 +27,9 @@
 
 #if defined(__FreeBSD__)
 #include <sys/endian.h>
+#elif defined(__APPLE__)
+#include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
 #else
 #include <endian.h>
 #endif
@@ -37,6 +40,14 @@
 
 #include "g722_encoder.h"
 #include "g722_decoder.h"
+
+/* Define byte order conversion functions for macOS */
+#if defined(__APPLE__)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#endif
 
 #define BUFFER_SIZE 10
 


### PR DESCRIPTION
This update introduces iOS build support and fixes broken macOS build process.

**Key changes:**

- **iOS support:**
    
    - Added `build_ios.sh` script to build for macOS, iOS device, and iOS simulator, producing an XCFramework.
    - Configured CMake to disable shared libraries and LTO for iOS builds (fixes incompatibility with XCFramework, disables bitcode)
- **macOS build improvements:**
    - Set default installation prefix to `~/Library/libg722` instead of `/usr/local`.
    - Disabled bitcode for macOS builds.
    - Updated Makefile to match new default install prefix logic.
- **Documentation updates:**
    - Expanded `README.md` with macOS and iOS build instructions.
    - Added environment variable instructions for macOS dynamic linking.
- **Code adjustments for macOS:**
    - Added endian conversion macros for Apple platforms in `test.c`.
- **Miscellaneous:**
    - Updated `.gitignore` to exclude `build/*` directories.
   
These changes make it easy to build and deploy `libg722` for Apple platforms, including universal binaries and XCFramework packaging for iOS.